### PR TITLE
Passes iAD info context.campaign instead of Properties

### DIFF
--- a/Analytics-iAds-Attribution/Classes/SEGADTracker.m
+++ b/Analytics-iAds-Attribution/Classes/SEGADTracker.m
@@ -23,10 +23,6 @@
     }
 
     SEGTrackPayload *track =(SEGTrackPayload *)context.payload;
-    if (![track.event isEqualToString:@"Application Installed"]) {
-        next(context);
-        return;
-    }
 
     if (![[ADClient sharedClient] respondsToSelector:@selector(requestAttributionDetailsWithBlock:)]) {
         next(context);

--- a/Analytics-iAds-Attribution/Classes/SEGADTracker.m
+++ b/Analytics-iAds-Attribution/Classes/SEGADTracker.m
@@ -62,14 +62,14 @@
             }
         };
 
-        NSMutableDictionary *mergeContext = [NSMutableDictionary dictionaryWithCapacity:attributionContext.count + track.context.count];
-        [mergeContext addEntriesFromDictionary:attributionContext];
-        [mergeContext addEntriesFromDictionary:track.context];
+        NSMutableDictionary *mergedContext = [NSMutableDictionary dictionaryWithCapacity:attributionContext.count + track.context.count];
+        [mergedContext addEntriesFromDictionary:attributionContext];
+        [mergedContext addEntriesFromDictionary:track.context];
         
         SEGContext *newContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
             ctx.payload = [[SEGTrackPayload alloc] initWithEvent:track.event
                                                       properties:track.properties
-                                                         context:mergeContext
+                                                         context:mergedContext
                                                     integrations:track.integrations];
         }];
 

--- a/Analytics-iAds-Attribution/Classes/SEGADTracker.m
+++ b/Analytics-iAds-Attribution/Classes/SEGADTracker.m
@@ -22,7 +22,7 @@
         return;
     }
 
-    SEGTrackPayload *track = context.payload;
+    SEGTrackPayload *track =(SEGTrackPayload *)context.payload;
     if (![track.event isEqualToString:@"Application Installed"]) {
         next(context);
         return;
@@ -47,10 +47,7 @@
             return;
         }
 
-        NSDictionary *attributionProperties = @{
-            @"provider" : @"Apple",
-            @"click_date" : attributionInfo[@"iad-click-date"] ?: @"unknown",
-            @"conversion_date" : attributionInfo[@"iad-conversion-date"] ?: @"unknown",
+        NSDictionary *attributionContext = @{
             @"campaign" : @{
                 @"source" : @"iAd",
                 @"name" : attributionInfo[@"iad-campaign-name"] ?: @"unknown",
@@ -58,18 +55,21 @@
                 @"ad_creative" : attributionInfo[@"iad-org-name"] ?: @"unknown",
                 @"ad_group" : attributionInfo[@"iad-adgroup-name"] ?: @"unknown",
                 @"id" : attributionInfo[@"iad-campaign-id"] ?: @"unknown",
-                @"ad_group_id" : attributionInfo[@"iad-adgroup-id"] ?: @"unknown"
+                @"ad_group_id" : attributionInfo[@"iad-adgroup-id"] ?: @"unknown",
+                @"provider" : @"Apple",
+                @"click_date" : attributionInfo[@"iad-click-date"] ?: @"unknown",
+                @"conversion_date" : attributionInfo[@"iad-conversion-date"] ?: @"unknown"
             }
         };
 
-        NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:attributionProperties.count + track.properties.count];
-        [properties addEntriesFromDictionary:attributionProperties];
-        [properties addEntriesFromDictionary:track.properties];
-
+        NSMutableDictionary *mergeContext = [NSMutableDictionary dictionaryWithCapacity:attributionContext.count + track.context.count];
+        [mergeContext addEntriesFromDictionary:attributionContext];
+        [mergeContext addEntriesFromDictionary:track.context];
+        
         SEGContext *newContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
             ctx.payload = [[SEGTrackPayload alloc] initWithEvent:track.event
-                                                      properties:properties
-                                                         context:track.context
+                                                      properties:track.properties
+                                                         context:mergeContext
                                                     integrations:track.integrations];
         }];
 

--- a/Example/Analytics-iAds-Attribution.xcodeproj/project.pbxproj
+++ b/Example/Analytics-iAds-Attribution.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		A61485EAF4ABD5117CD4CA99 /* [CP] Check Pods Manifest.lock */ = {
@@ -339,7 +339,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		BF4B15D1FC8F9E6D78E3F9DA /* [CP] Embed Pods Frameworks */ = {

--- a/Example/Analytics-iAds-Attribution.xcodeproj/project.pbxproj
+++ b/Example/Analytics-iAds-Attribution.xcodeproj/project.pbxproj
@@ -23,7 +23,8 @@
 		71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71719F9D1E33DC2100824A3D /* LaunchScreen.storyboard */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		8E0F501CDED62421A2337736 /* libPods-Analytics-iAds-Attribution_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5198132FE0FF52E54CABB5E1 /* libPods-Analytics-iAds-Attribution_Tests.a */; };
-		958407551F2A5D7900A727B7 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 958407541F2A5D7900A727B7 /* iAd.framework */; };
+		9584075D1F2A6BF600A727B7 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9584075C1F2A6BF600A727B7 /* AdSupport.framework */; };
+		9584075E1F2A6C0D00A727B7 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 958407541F2A5D7900A727B7 /* iAd.framework */; };
 		C77AA50C2AD245BC2F75E7A5 /* libPods-Analytics-iAds-Attribution_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 829157BA6D089E989B962AEB /* libPods-Analytics-iAds-Attribution_Example.a */; };
 /* End PBXBuildFile section */
 
@@ -64,6 +65,7 @@
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		87A889A3B30947939F15867A /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		958407541F2A5D7900A727B7 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
+		9584075C1F2A6BF600A727B7 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		B861B1A0758F4D44A0F83412 /* Pods-Analytics-iAds-Attribution_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Analytics-iAds-Attribution_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Analytics-iAds-Attribution_Example/Pods-Analytics-iAds-Attribution_Example.release.xcconfig"; sourceTree = "<group>"; };
 		C07D4CA328DD61C08C3CE5BA /* Pods-Analytics-iAds-Attribution_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Analytics-iAds-Attribution_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Analytics-iAds-Attribution_Tests/Pods-Analytics-iAds-Attribution_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		D6CA851E017D226A42FDA1DF /* Pods-Analytics-iAds-Attribution_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Analytics-iAds-Attribution_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Analytics-iAds-Attribution_Tests/Pods-Analytics-iAds-Attribution_Tests.release.xcconfig"; sourceTree = "<group>"; };
@@ -76,7 +78,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				958407551F2A5D7900A727B7 /* iAd.framework in Frameworks */,
+				9584075E1F2A6C0D00A727B7 /* iAd.framework in Frameworks */,
+				9584075D1F2A6BF600A727B7 /* AdSupport.framework in Frameworks */,
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
@@ -133,6 +136,7 @@
 		6003F58C195388D20070C39A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9584075C1F2A6BF600A727B7 /* AdSupport.framework */,
 				958407541F2A5D7900A727B7 /* iAd.framework */,
 				6003F58D195388D20070C39A /* Foundation.framework */,
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
@@ -254,6 +258,9 @@
 				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = f2prateek;
 				TargetAttributes = {
+					6003F589195388D20070C39A = {
+						DevelopmentTeam = CL7W6YM8AN;
+					};
 					6003F5AD195388D20070C39A = {
 						TestTargetID = 6003F589195388D20070C39A;
 					};
@@ -538,6 +545,7 @@
 			baseConfigurationReference = F5F562BF7C980D74A8C9D153 /* Pods-Analytics-iAds-Attribution_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = CL7W6YM8AN;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Analytics-iAds-Attribution/Analytics-iAds-Attribution-Prefix.pch";
 				INFOPLIST_FILE = "Analytics-iAds-Attribution/Analytics-iAds-Attribution-Info.plist";
@@ -553,6 +561,7 @@
 			baseConfigurationReference = B861B1A0758F4D44A0F83412 /* Pods-Analytics-iAds-Attribution_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = CL7W6YM8AN;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Analytics-iAds-Attribution/Analytics-iAds-Attribution-Prefix.pch";
 				INFOPLIST_FILE = "Analytics-iAds-Attribution/Analytics-iAds-Attribution-Info.plist";

--- a/Example/Analytics-iAds-Attribution.xcodeproj/project.pbxproj
+++ b/Example/Analytics-iAds-Attribution.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71719F9D1E33DC2100824A3D /* LaunchScreen.storyboard */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		8E0F501CDED62421A2337736 /* libPods-Analytics-iAds-Attribution_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5198132FE0FF52E54CABB5E1 /* libPods-Analytics-iAds-Attribution_Tests.a */; };
+		958407551F2A5D7900A727B7 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 958407541F2A5D7900A727B7 /* iAd.framework */; };
 		C77AA50C2AD245BC2F75E7A5 /* libPods-Analytics-iAds-Attribution_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 829157BA6D089E989B962AEB /* libPods-Analytics-iAds-Attribution_Example.a */; };
 /* End PBXBuildFile section */
 
@@ -37,7 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		334A46C7B1653C53F18FD658 /* Analytics-iAds-Attribution.podspec */ = {isa = PBXFileReference; includeInIndex = 1; name = "Analytics-iAds-Attribution.podspec"; path = "../Analytics-iAds-Attribution.podspec"; sourceTree = "<group>"; };
+		334A46C7B1653C53F18FD658 /* Analytics-iAds-Attribution.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "Analytics-iAds-Attribution.podspec"; path = "../Analytics-iAds-Attribution.podspec"; sourceTree = "<group>"; };
 		5198132FE0FF52E54CABB5E1 /* libPods-Analytics-iAds-Attribution_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Analytics-iAds-Attribution_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58A195388D20070C39A /* Analytics-iAds-Attribution_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Analytics-iAds-Attribution_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -61,12 +62,13 @@
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		829157BA6D089E989B962AEB /* libPods-Analytics-iAds-Attribution_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Analytics-iAds-Attribution_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		87A889A3B30947939F15867A /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		87A889A3B30947939F15867A /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		958407541F2A5D7900A727B7 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
 		B861B1A0758F4D44A0F83412 /* Pods-Analytics-iAds-Attribution_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Analytics-iAds-Attribution_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Analytics-iAds-Attribution_Example/Pods-Analytics-iAds-Attribution_Example.release.xcconfig"; sourceTree = "<group>"; };
 		C07D4CA328DD61C08C3CE5BA /* Pods-Analytics-iAds-Attribution_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Analytics-iAds-Attribution_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Analytics-iAds-Attribution_Tests/Pods-Analytics-iAds-Attribution_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		D6CA851E017D226A42FDA1DF /* Pods-Analytics-iAds-Attribution_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Analytics-iAds-Attribution_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Analytics-iAds-Attribution_Tests/Pods-Analytics-iAds-Attribution_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		F5F562BF7C980D74A8C9D153 /* Pods-Analytics-iAds-Attribution_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Analytics-iAds-Attribution_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Analytics-iAds-Attribution_Example/Pods-Analytics-iAds-Attribution_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		F8610A9F409FEDBC05E25A88 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		F8610A9F409FEDBC05E25A88 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				958407551F2A5D7900A727B7 /* iAd.framework in Frameworks */,
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
@@ -130,6 +133,7 @@
 		6003F58C195388D20070C39A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				958407541F2A5D7900A727B7 /* iAd.framework */,
 				6003F58D195388D20070C39A /* Foundation.framework */,
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
@@ -247,7 +251,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = SEGAD;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = f2prateek;
 				TargetAttributes = {
 					6003F5AD195388D20070C39A = {
@@ -459,14 +463,19 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -499,13 +508,18 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;

--- a/Example/Analytics-iAds-Attribution.xcodeproj/xcshareddata/xcschemes/Analytics-iAds-Attribution-Example.xcscheme
+++ b/Example/Analytics-iAds-Attribution.xcodeproj/xcshareddata/xcschemes/Analytics-iAds-Attribution-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Analytics-iAds-Attribution/SEGADAppDelegate.m
+++ b/Example/Analytics-iAds-Attribution/SEGADAppDelegate.m
@@ -14,9 +14,14 @@
     // Configure the client with the iAD middleware.
     configuration.middlewares = @[ [SEGADTracker middleware] ];
     configuration.trackApplicationLifecycleEvents = YES;
-
+    configuration.flushAt = 1;
     [SEGAnalytics setupWithConfiguration:configuration];
     [SEGAnalytics debug:YES];
+    
+    [[SEGAnalytics sharedAnalytics] track:@"Item Purchased"
+                               properties:@{ @"item": @"Sword of Heracles", @"revenue": @2.95 }];
+    
+    [[SEGAnalytics sharedAnalytics] track:@"Testing Kochava"];
 
     return YES;
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Analytics (3.6.0)
-  - Analytics-iAds-Attribution (1.0.0):
+  - Analytics-iAds-Attribution (2.0.1):
     - Analytics (~> 3.6.0)
   - Expecta (1.0.5)
   - Specta (1.0.6)
@@ -13,14 +13,14 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Analytics-iAds-Attribution:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Analytics: 15be3e651d22cc811f44df65698538236676437b
-  Analytics-iAds-Attribution: 0ea8bbe0d7f0dba7fb028648e8a65b66b253fb23
+  Analytics-iAds-Attribution: 1b318e87ec527a73a2419290128d6835686b7dd6
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
 PODFILE CHECKSUM: 072dfeae01d770684d03789212831987f310ad69
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+XCPRETTY := xcpretty -c && exit ${PIPESTATUS[0]}
+
+SDK ?= "iphonesimulator"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 5"
+PROJECT := Analytics-iAds-Attribution
+XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
+
+install: Example/Podfile Analytics-iAds-Attribution.podspec
+	pod repo update
+	pod install --project-directory=Example
+
+clean:
+	xcodebuild $(XC_ARGS) clean | $(XCPRETTY)
+
+build:
+	xcodebuild $(XC_ARGS) | $(XCPRETTY)
+
+test:
+	xcodebuild test $(XC_ARGS) | $(XCPRETTY)
+
+xcbuild:
+	xctool $(XC_ARGS)
+
+xctest:
+	xctool test $(XC_ARGS)
+
+.PHONY: test build xctest xcbuild clean
+.SILENT:

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@
 
 Records [iAd attribution information](http://searchads.apple.com/help/measure-results/) using [analytics-ios](https://github.com/segmentio/analytics-ios).
 
-When it is able to retrieve iAd information, it will augment the `Application Installed` event using the [Segment mobile spec](https://segment.com/docs/spec/mobile/#application-installed). The attribution information is transformed to Segment properties this way:
+When it is able to retrieve iAd information, it will augment the `Application Installed` event using the [Segment mobile spec](https://segment.com/docs/spec/mobile/#application-installed). The attribution information is transformed to Segment context this way:
 
 ```obj-c
-[analytics track:@"Application Installed" properties:@{
-    @"provider" : @"Apple",
-    @"click_date" : attributionInfo[@"iad-click-date"],
-    @"conversion_date" : attributionInfo[@"iad-conversion-date"],
-    @"campaign" : @{
+[analytics track:@"Application Installed",
+    @"context" : @{
+      @"campaign" : @{
+        @"provider" : @"Apple",
+        @"click_date" : attributionInfo[@"iad-click-date"],
+        @"conversion_date" : attributionInfo[@"iad-conversion-date"],
         @"source" : @"iAd",
         @"name" : attributionInfo[@"iad-campaign-name"],
         @"content" : attributionInfo[@"iad-keyword"],
@@ -21,11 +22,13 @@ When it is able to retrieve iAd information, it will augment the `Application In
         @"ad_group" : attributionInfo[@"iad-adgroup-name"],
         @"id" : attributionInfo[@"iad-campaign-id"],
         @"ad_group_id" : attributionInfo[@"iad-adgroup-id"]
+      }    
     }
 }];
 ```
 
-https://cloudup.com/cVmP8uJI4XD
+Because this information in passed through the `context` object, this will not be received by other downstream integrations, unless explicitly mapped. [Kochava](https://segment.com/docs/integrations/kochava/) is currently the only integration which supports Apple Search Ads.
+
 
 ## Example
 


### PR DESCRIPTION
Waiting on a final confirmation from Kochava that
* All info is expected to be passed in through `context.campaign`
* This won't be a breaking change for current users