### PR TITLE
bump Analytics dependency to 3.7.x

### DIFF
--- a/Analytics-iAds-Attribution.podspec
+++ b/Analytics-iAds-Attribution.podspec
@@ -22,5 +22,5 @@ Analytics-iAds-Attribution requests iAd attribution information and sends a trac
 
   s.source_files = 'Analytics-iAds-Attribution/Classes/**/*'
 
-  s.dependency 'Analytics', '~> 3.6.0'
+  s.dependency 'Analytics', '~> 3.7.0'
 end

--- a/Analytics-iAds-Attribution.podspec
+++ b/Analytics-iAds-Attribution.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Analytics-iAds-Attribution'
-  s.version          = '3.0.0'
+  s.version          = '3.0.1'
   s.summary          = 'Measure iAds attribution data with analytics-ios.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
It appears there are no breaking changes between Analytics 3.6 and 3.7:

https://github.com/segmentio/analytics-ios/blob/master/CHANGELOG.md#version-370-beta-27th-august-2018

Fixes #7